### PR TITLE
Fix default export

### DIFF
--- a/d.ts/polly-js.d.ts
+++ b/d.ts/polly-js.d.ts
@@ -16,5 +16,5 @@ declare interface Polly {
 declare var polly: () => Polly;
 
 declare module "polly-js" {
-    export = polly;
+    export default polly;
 }


### PR DESCRIPTION
The proper way to import polly seems to be `import polly from 'polly-js'`, however using `export = polly` will throw a syntax error on that import. This fixes that.