### PR TITLE
Pass retry count at executeForPromise

### DIFF
--- a/src/polly.js
+++ b/src/polly.js
@@ -44,7 +44,7 @@
 
         return new Promise(function (resolve, reject) {
             function execute() {
-                var original = cb();
+                var original = cb(count);
 
                 original.then(function (e) {
                     resolve(e);


### PR DESCRIPTION
It can be useful for logging scenario:
```javascript
polly().retry(2)
  .executeForPromise((count) => {
  if (count > 0) {
    logger.info(`Retry number ${count}`);
  }
  })
```