### PR TITLE
Fix TS type definition

### DIFF
--- a/d.ts/polly-js.d.ts
+++ b/d.ts/polly-js.d.ts
@@ -1,28 +1,39 @@
-type Info = {
-    count: number;
-};
-
-declare interface AsyncRetryable {
-    executeForPromise<T>(fn: (info: Info) => Promise<T>): Promise<T>;
-    executeForNode(
-        fn: (cb: (err?: object, data?: any) => any, info: Info) => any,
-        cb?: (err?: object, data?: any) => any
-    ): void;
-}
-
-declare interface Retryable extends AsyncRetryable {
-    execute(fn: (info: Info) => any): any;
-}
-
-declare interface Polly {
-    handle(fn: (err: any) => boolean): Polly;
-    retry(numRetries: number): Retryable;
-    waitAndRetry(delays: number[]): AsyncRetryable;
-    waitAndRetry(numRetries: number): AsyncRetryable;
-}
-
-declare var polly: () => Polly;
+// tslint:disable
+// Type definitions for polly-js
 
 declare module 'polly-js' {
-    export default polly;
-}
+    function polly (): polly.Polly;
+
+    namespace polly {
+      type Info = {
+        count: number;
+      };
+
+      interface AsyncRetryable {
+        executeForPromise<T> (fn: (info: Info) => Promise<T>): Promise<T>;
+        executeForNode (
+          fn: (cb: (err?: object, data?: any) => any, info: Info) => any,
+          cb?: (err?: object, data?: any) => any
+        ): void;
+      }
+
+      interface Retryable extends AsyncRetryable {
+        execute (fn: (info: Info) => any): any;
+      }
+
+      interface Polly {
+        handle (fn: (err: any) => boolean): Polly;
+        retry (numRetries: number): Retryable;
+        waitAndRetry (delays: number[]): AsyncRetryable;
+        waitAndRetry (numRetries: number): AsyncRetryable;
+      }
+
+      type PollyDefaults = {
+        delay: number;
+      }
+
+      const defaults: PollyDefaults;
+    }
+
+    export = polly;
+  }


### PR DESCRIPTION
Typescript type definitions are wrong and unusable. I fixed them and added `defaults` variable.